### PR TITLE
Disallow stdlib functions that print to stdio

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -4,7 +4,7 @@ set -e
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github "
-DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(')
+DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/pion/datachannel
 
 require (
+	github.com/pion/logging v0.2.1
 	github.com/pion/sctp v1.4.4
 	github.com/pion/transport v0.6.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
+github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
 github.com/pion/sctp v1.4.4 h1:0d3c1g7OtvPYMVWPSNu8w37yJaKUcjCupVQ1zVcnIOc=
 github.com/pion/sctp v1.4.4/go.mod h1:oS057xrxwNbgFWap0buUuAJalfVezrOEwdmEoydf5x4=
 github.com/pion/transport v0.6.0 h1:WAoyJg/6OI8dhCVFl/0JHTMd1iu2iHgGUXevptMtJ3U=


### PR DESCRIPTION
All printing to stdio must be done via pion/logging,
all calls to common printing functions will not cause CI
to fail

Relates to pion/webrtc#361
