### PR TITLE
Disallow stdlib functions that print to stdio

### DIFF
--- a/.github/lint-disallowed-functions-in-library.sh
+++ b/.github/lint-disallowed-functions-in-library.sh
@@ -4,7 +4,7 @@ set -e
 # Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 EXCLUDE_DIRECTORIES="--exclude-dir=examples --exclude-dir=.git --exclude-dir=.github "
-DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(')
+DISALLOWED_FUNCTIONS=('os.Exit(' 'panic(' 'Fatal(' 'Fatalf(' 'Fatalln(' 'fmt.Println(' 'fmt.Printf(' 'log.Print(' 'log.Println(' 'log.Printf(')
 
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"


### PR DESCRIPTION
Relates to pion/webrtc#361

The lint script change in #14 was dropped somehow.  Adding it.