### PR TITLE
Update sctp version to 1.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/pion/datachannel
 
 require (
 	github.com/pion/logging v0.2.1
-	github.com/pion/sctp v1.6.0
+	github.com/pion/sctp v1.6.1
 	github.com/pion/transport v0.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
 github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
-github.com/pion/sctp v1.6.0 h1:WMfBhw6vHUl68NVsFOYjngPpr/+OMW/4esIH8U3Pd5s=
-github.com/pion/sctp v1.6.0/go.mod h1:2OUthw9DpDB3AGoHFHMUrxBlhLXPJfrn/Q52qECtGZI=
+github.com/pion/sctp v1.6.1 h1:4o1M+xCaz7Q8P5EmdqvbkECLIbkOk2yIRv9b1Z01MKc=
+github.com/pion/sctp v1.6.1/go.mod h1:2OUthw9DpDB3AGoHFHMUrxBlhLXPJfrn/Q52qECtGZI=
 github.com/pion/transport v0.7.0 h1:EsXN8TglHMlKZMo4ZGqwK6QgXBu0WYg7wfGMWIXsS+w=
 github.com/pion/transport v0.7.0/go.mod h1:iWZ07doqOosSLMhZ+FXUTq+TamDoXSllxpbGcfkCmbE=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
Update sctp version to v1.6.1 which resolves the issue with retransmission timers not closed on writeLoop exit.

Relates to pion/sctp#42
.
