### PR TITLE
[WIP] Fix eof on read

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/pion/datachannel
 
 require (
 	github.com/pion/logging v0.2.1
-	github.com/pion/sctp v1.6.1
+	github.com/pion/sctp v1.6.2
 	github.com/pion/transport v0.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pion/logging v0.2.1 h1:LwASkBKZ+2ysGJ+jLv1E/9H1ge0k1nTfi1X+5zirkDk=
 github.com/pion/logging v0.2.1/go.mod h1:k0/tDVsRCX2Mb2ZEmTqNa7CWsQPc+YYCB7Q+5pahoms=
-github.com/pion/sctp v1.6.1 h1:4o1M+xCaz7Q8P5EmdqvbkECLIbkOk2yIRv9b1Z01MKc=
-github.com/pion/sctp v1.6.1/go.mod h1:2OUthw9DpDB3AGoHFHMUrxBlhLXPJfrn/Q52qECtGZI=
+github.com/pion/sctp v1.6.2 h1:K/j9rsv4Lv97znjMum6xGNfeBl7LwVlVjGbTfJ9a+0Q=
+github.com/pion/sctp v1.6.2/go.mod h1:cCqpLdYvgEUdl715+qbWtgT439CuQrAgy8BZTp0aEfA=
 github.com/pion/transport v0.7.0 h1:EsXN8TglHMlKZMo4ZGqwK6QgXBu0WYg7wfGMWIXsS+w=
 github.com/pion/transport v0.7.0/go.mod h1:iWZ07doqOosSLMhZ+FXUTq+TamDoXSllxpbGcfkCmbE=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
#### Description
Currently, on receipt of EOF pion/datachannel closes the outgoing channel.

It is the requirement from libp2p that even EOF is received on a datachannel, the datachannel be available for write until the app calls Close on the datachannel. (in the context of detached mode)

The sctp branch this PR uses solves EOF related problems. This fix in datachannel module will complete the whole issue around EOF discussed in pion/webrtc#652.

#### Reference issue
Fixes pion/webrtc#652

#### TODO
Before merging this, we will need to tag sctp this PR depends on.
