### PR TITLE
Fix alignment of struct fields

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -37,14 +37,15 @@ type ReadWriteCloser interface {
 // DataChannel represents a data channel
 type DataChannel struct {
 	Config
-	stream *sctp.Stream
-	log    logging.LeveledLogger
 
 	// stats
 	messagesSent     uint32
 	messagesReceived uint32
 	bytesSent        uint64
 	bytesReceived    uint64
+
+	stream *sctp.Stream
+	log    logging.LeveledLogger
 }
 
 // Config is used to configure the data channel.


### PR DESCRIPTION
Relates to pion/webrtc#750

By changing the order of the DataChannel struct fields solves the crash on 32-bit OS (confirmed with ubuntu) 