### PR TITLE
Fix whitespace and stylecheck lint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Michiel De Backker](https://github.com/backkem) - *Public API*
 * [Yutaka Takeda](https://github.com/enobufs) - *PR-SCTP*
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/datachannel.go
+++ b/datachannel.go
@@ -1,3 +1,4 @@
+// Package datachannel implements WebRTC Data Channels
 package datachannel
 
 import (
@@ -173,7 +174,6 @@ func Server(stream *sctp.Stream, config *Config) (*DataChannel, error) {
 		return nil, err
 	}
 	return dataChannel, nil
-
 }
 
 // Read reads a packet of len(p) bytes as binary data

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -395,7 +395,6 @@ func TestDataChannel(t *testing.T) {
 	t.Run("ChannelTypePartialReliableTimedUnordered", func(t *testing.T) {
 		prUnorderedTest(t, ChannelTypePartialReliableTimedUnordered)
 	})
-
 }
 
 func TestDataChannelBufferedAmount(t *testing.T) {


### PR DESCRIPTION
Prepare to update golangci-lint to 1.19.1.