### PR TITLE
Fix handling of Empty messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Yutaka Takeda](https://github.com/enobufs) - *PR-SCTP*
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Atsushi Watanabe](https://github.com/at-wat)
+* [Norman Rasmussen](https://github.com/normanr) - *Fix Empty DataChannel messages*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/datachannel.go
+++ b/datachannel.go
@@ -210,6 +210,10 @@ func (c *DataChannel) ReadDataChannel(p []byte) (int, bool, error) {
 		case sctp.PayloadTypeWebRTCString, sctp.PayloadTypeWebRTCStringEmpty:
 			isString = true
 		}
+		switch ppi {
+		case sctp.PayloadTypeWebRTCBinaryEmpty, sctp.PayloadTypeWebRTCStringEmpty:
+			n = 0
+		}
 
 		atomic.AddUint32(&c.messagesReceived, 1)
 		atomic.AddUint64(&c.bytesReceived, uint64(n))
@@ -297,6 +301,10 @@ func (c *DataChannel) WriteDataChannel(p []byte, isString bool) (n int, err erro
 	atomic.AddUint32(&c.messagesSent, 1)
 	atomic.AddUint64(&c.bytesSent, uint64(len(p)))
 
+	if len(p) == 0 {
+		_, err := c.stream.WriteSCTP([]byte{0}, ppi)
+		return 0, err
+	}
 	return c.stream.WriteSCTP(p, ppi)
 }
 

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -452,6 +452,26 @@ func TestDataChannelBufferedAmount(t *testing.T) {
 		bridgeProcessAtLeastOne(br)
 	}
 
+	n, err := dc0.Write([]byte{})
+	assert.Nil(t, err, "Write() should succeed")
+	assert.Equal(t, 0, n, "data length should match")
+	assert.Equal(t, uint64(1), dc0.BufferedAmount(), "incorrect bufferedAmount")
+
+	n, err = dc0.Write([]byte{0})
+	assert.Nil(t, err, "Write() should succeed")
+	assert.Equal(t, 1, n, "data length should match")
+	assert.Equal(t, uint64(2), dc0.BufferedAmount(), "incorrect bufferedAmount")
+
+	bridgeProcessAtLeastOne(br)
+
+	n, err = dc1.Read(rData)
+	assert.Nil(t, err, "Read() should succeed")
+	assert.Equal(t, n, 0, "received length should match")
+
+	n, err = dc1.Read(rData)
+	assert.Nil(t, err, "Read() should succeed")
+	assert.Equal(t, n, 1, "received length should match")
+
 	dc0.SetBufferedAmountLowThreshold(1500)
 	assert.Equal(t, uint64(1500), dc0.BufferedAmountLowThreshold(), "incorrect bufferedAmountLowThreshold")
 	dc0.OnBufferedAmountLow(func() {
@@ -464,7 +484,7 @@ func TestDataChannelBufferedAmount(t *testing.T) {
 		n, err = dc0.Write(sData)
 		assert.Nil(t, err, "Write() should succeed")
 		assert.Equal(t, len(sData), n, "data length should match")
-		assert.Equal(t, uint64(len(sData)*(i+1)), dc0.BufferedAmount(), "incorrect bufferedAmount")
+		assert.Equal(t, uint64(len(sData)*(i+1)+2), dc0.BufferedAmount(), "incorrect bufferedAmount")
 	}
 
 	go func() {
@@ -547,6 +567,21 @@ func TestStats(t *testing.T) {
 	assert.Equal(t, dc0.BytesSent(), bytesSent)
 	assert.Equal(t, dc0.MessagesSent(), uint32(2))
 
+	n, err = dc0.Write([]byte{0})
+	assert.NoError(t, err, "Write() should succeed")
+	assert.Equal(t, 1, n, "data length should match")
+	bytesSent += uint64(n)
+
+	assert.Equal(t, dc0.BytesSent(), bytesSent)
+	assert.Equal(t, dc0.MessagesSent(), uint32(3))
+
+	n, err = dc0.Write([]byte{})
+	assert.NoError(t, err, "Write() should succeed")
+	assert.Equal(t, 0, n, "data length should match")
+
+	assert.Equal(t, dc0.BytesSent(), bytesSent)
+	assert.Equal(t, dc0.MessagesSent(), uint32(4))
+
 	bridgeProcessAtLeastOne(br)
 
 	var bytesRead uint64
@@ -564,6 +599,21 @@ func TestStats(t *testing.T) {
 
 	assert.Equal(t, dc1.BytesReceived(), bytesRead)
 	assert.Equal(t, dc1.MessagesReceived(), uint32(2))
+
+	n, err = dc1.Read(rbuf)
+	assert.NoError(t, err, "Read() should succeed")
+	bytesRead += uint64(n)
+
+	assert.Equal(t, n, 1)
+	assert.Equal(t, dc1.BytesReceived(), bytesRead)
+	assert.Equal(t, dc1.MessagesReceived(), uint32(3))
+
+	n, err = dc1.Read(rbuf)
+	assert.NoError(t, err, "Read() should succeed")
+
+	assert.Equal(t, n, 0)
+	assert.Equal(t, dc1.BytesReceived(), bytesRead)
+	assert.Equal(t, dc1.MessagesReceived(), uint32(4))
 
 	assert.NoError(t, dc0.Close())
 	assert.NoError(t, dc1.Close())


### PR DESCRIPTION
Empty messages should be sent as one zero byte. When receiving an Empty
message, the contents should be ignored.

Currently pion/webrtc converts zero-byte messages into single null-byte messages and datachannels transmits it as a regular message. This fixes datachannels to send the correct payload and strip the payload for Empty messages.

I'll send a PR for webrtc to remove the conversion from webrtc too.