### PR TITLE
Set reliability params on DCEP ACK

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -61,23 +61,6 @@ type Config struct {
 }
 
 func newDataChannel(stream *sctp.Stream, config *Config) (*DataChannel, error) {
-	switch config.ChannelType {
-	case ChannelTypeReliable:
-		stream.SetReliabilityParams(false, sctp.ReliabilityTypeReliable, config.ReliabilityParameter)
-	case ChannelTypeReliableUnordered:
-		stream.SetReliabilityParams(true, sctp.ReliabilityTypeReliable, config.ReliabilityParameter)
-	case ChannelTypePartialReliableRexmit:
-		stream.SetReliabilityParams(false, sctp.ReliabilityTypeRexmit, config.ReliabilityParameter)
-	case ChannelTypePartialReliableRexmitUnordered:
-		stream.SetReliabilityParams(true, sctp.ReliabilityTypeRexmit, config.ReliabilityParameter)
-	case ChannelTypePartialReliableTimed:
-		stream.SetReliabilityParams(false, sctp.ReliabilityTypeTimed, config.ReliabilityParameter)
-	case ChannelTypePartialReliableTimedUnordered:
-		stream.SetReliabilityParams(true, sctp.ReliabilityTypeTimed, config.ReliabilityParameter)
-	default:
-		return nil, fmt.Errorf("unable to create datachannel, invalid ChannelType: %v ", config.ChannelType)
-	}
-
 	return &DataChannel{
 		Config: *config,
 		stream: stream,
@@ -173,6 +156,11 @@ func Server(stream *sctp.Stream, config *Config) (*DataChannel, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = dataChannel.commitReliabilityParams()
+	if err != nil {
+		return nil, err
+	}
 	return dataChannel, nil
 }
 
@@ -255,15 +243,21 @@ func (c *DataChannel) handleDCEP(data []byte) error {
 
 	switch msg := msg.(type) {
 	case *channelOpen:
+		c.log.Debug("Received DATA_CHANNEL_OPEN")
 		err = c.writeDataChannelAck()
 		if err != nil {
 			return fmt.Errorf("failed to ACK channel open: %v", err)
 		}
-		// TODO: Should not happen?
+		// Note: DATA_CHANNEL_OPEN message is handled inside Server() method.
+		// Therefore, the message will not reach here.
 
 	case *channelAck:
+		c.log.Debug("Received DATA_CHANNEL_ACK")
+		err = c.commitReliabilityParams()
+		if err != nil {
+			return err
+		}
 		// TODO: handle ChannelAck (https://tools.ietf.org/html/draft-ietf-rtcweb-data-protocol-09#section-5.2)
-		// TODO: handle?
 
 	default:
 		return fmt.Errorf("unhandled DataChannel message %v", msg)
@@ -361,4 +355,24 @@ func (c *DataChannel) SetBufferedAmountLowThreshold(th uint64) {
 // number of bytes of outgoing data buffered is lower than the threshold.
 func (c *DataChannel) OnBufferedAmountLow(f func()) {
 	c.stream.OnBufferedAmountLow(f)
+}
+
+func (c *DataChannel) commitReliabilityParams() error {
+	switch c.Config.ChannelType {
+	case ChannelTypeReliable:
+		c.stream.SetReliabilityParams(false, sctp.ReliabilityTypeReliable, c.Config.ReliabilityParameter)
+	case ChannelTypeReliableUnordered:
+		c.stream.SetReliabilityParams(true, sctp.ReliabilityTypeReliable, c.Config.ReliabilityParameter)
+	case ChannelTypePartialReliableRexmit:
+		c.stream.SetReliabilityParams(false, sctp.ReliabilityTypeRexmit, c.Config.ReliabilityParameter)
+	case ChannelTypePartialReliableRexmitUnordered:
+		c.stream.SetReliabilityParams(true, sctp.ReliabilityTypeRexmit, c.Config.ReliabilityParameter)
+	case ChannelTypePartialReliableTimed:
+		c.stream.SetReliabilityParams(false, sctp.ReliabilityTypeTimed, c.Config.ReliabilityParameter)
+	case ChannelTypePartialReliableTimedUnordered:
+		c.stream.SetReliabilityParams(true, sctp.ReliabilityTypeTimed, c.Config.ReliabilityParameter)
+	default:
+		return fmt.Errorf("invalid ChannelType: %v ", c.Config.ChannelType)
+	}
+	return nil
 }

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -152,6 +152,11 @@ func prOrderedTest(t *testing.T, channelType ChannelType) {
 	assert.True(t, reflect.DeepEqual(dc0.Config, *cfg), "local config should match")
 	assert.True(t, reflect.DeepEqual(dc1.Config, *cfg), "remote config should match")
 
+	err = dc0.commitReliabilityParams()
+	assert.NoError(t, err, "should succeed")
+	err = dc1.commitReliabilityParams()
+	assert.NoError(t, err, "should succeed")
+
 	var n int
 
 	binary.BigEndian.PutUint32(sbuf, 1)
@@ -216,6 +221,11 @@ func prUnorderedTest(t *testing.T, channelType ChannelType) {
 
 	assert.True(t, reflect.DeepEqual(dc0.Config, *cfg), "local config should match")
 	assert.True(t, reflect.DeepEqual(dc1.Config, *cfg), "remote config should match")
+
+	err = dc0.commitReliabilityParams()
+	assert.NoError(t, err, "should succeed")
+	err = dc1.commitReliabilityParams()
+	assert.NoError(t, err, "should succeed")
 
 	var n int
 
@@ -368,6 +378,11 @@ func TestDataChannel(t *testing.T) {
 
 		assert.True(t, reflect.DeepEqual(dc0.Config, *cfg), "local config should match")
 		assert.True(t, reflect.DeepEqual(dc1.Config, *cfg), "remote config should match")
+
+		err = dc0.commitReliabilityParams()
+		assert.NoError(t, err, "should succeed")
+		err = dc1.commitReliabilityParams()
+		assert.NoError(t, err, "should succeed")
 
 		var n int
 


### PR DESCRIPTION
Relates to pion/webrtc#1270

#### Description
Current pion/datachannel immaturely enables partial-reliability behavior during the DCEP handshake. Consequently, causing ErrorChunk on the receipt of FwdTSN over a lossy connection.
RFC 3758 clearly states that DCEP handshake must be done over a reliable ordered channel.

This PR defers the passing of reliability parameters to the SCTP stream until the DCEP handshake is complete (on a receipt of Ack).

See pion/webrtc#1270 for more details.