### PR TITLE
Add acknowledged variable to DataChannel

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -43,6 +43,7 @@ type DataChannel struct {
 	messagesReceived uint32
 	bytesSent        uint64
 	bytesReceived    uint64
+	acknowledged     bool
 
 	stream *sctp.Stream
 	log    logging.LeveledLogger
@@ -235,6 +236,7 @@ func (c *DataChannel) handleDCEP(data []byte) error {
 	switch msg := msg.(type) {
 	case *channelAck:
 		c.log.Debug("Received DATA_CHANNEL_ACK")
+		c.acknowledged = true
 		if err = c.commitReliabilityParams(); err != nil {
 			return err
 		}


### PR DESCRIPTION
#### Description

Added an acknowledged boolean to the DataChannel struct so you can check that before saying the data channel is open in https://github.com/pion/webrtc/blob/338dfa81f1f8e6cd239503dadc454cbb65c0229a/peerconnection.go#L1326

#### Reference issue
Fixes https://github.com/pion/webrtc/issues/1063
