### PR TITLE
Use go value format for handleDCEP error

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -274,7 +274,7 @@ func (c *DataChannel) handleDCEP(data []byte) error {
 		}
 		c.onOpenComplete()
 	default:
-		return fmt.Errorf("%w %s", ErrInvalidMessageType, msg)
+		return fmt.Errorf("%w %v", ErrInvalidMessageType, msg)
 	}
 
 	return nil


### PR DESCRIPTION
Previously it used the string specifier which did
not work well for a struct type.
