### PR TITLE
Return useful error for incorrect channel type

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -287,7 +287,7 @@ func (c *DataChannel) handleDCEP(data []byte) error {
 	case *channelAck:
 		c.onOpenComplete()
 	default:
-		return fmt.Errorf("%w %v", ErrInvalidMessageType, msg)
+		return fmt.Errorf("%w, wanted ACK got %v", ErrUnexpectedDataChannelType, msg)
 	}
 
 	return nil

--- a/message.go
+++ b/message.go
@@ -11,6 +11,7 @@ import (
 type message interface {
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
+	String() string
 }
 
 // messageType is the first byte in a DataChannel message that specifies type

--- a/message_channel_ack.go
+++ b/message_channel_ack.go
@@ -23,3 +23,7 @@ func (c *channelAck) Unmarshal(_ []byte) error {
 	// Message type already checked in Parse and there is no further data
 	return nil
 }
+
+func (c channelAck) String() string {
+	return "ACK"
+}

--- a/message_channel_open.go
+++ b/message_channel_open.go
@@ -75,6 +75,23 @@ const (
 	ChannelTypePartialReliableTimedUnordered ChannelType = 0x82
 )
 
+func (c ChannelType) String() string {
+	switch c {
+	case ChannelTypeReliable:
+	case ChannelTypeReliableUnordered:
+		return "ReliableUnordered"
+	case ChannelTypePartialReliableRexmit:
+		return "PartialReliableRexmit"
+	case ChannelTypePartialReliableRexmitUnordered:
+		return "PartialReliableRexmitUnordered"
+	case ChannelTypePartialReliableTimed:
+		return "PartialReliableTimed"
+	case ChannelTypePartialReliableTimedUnordered:
+		return "PartialReliableTimedUnordered"
+	}
+	return "Unknown"
+}
+
 // ChannelPriority enums
 const (
 	ChannelPriorityBelowNormal uint16 = 128
@@ -123,4 +140,8 @@ func (c *channelOpen) Unmarshal(raw []byte) error {
 	c.Label = raw[channelOpenHeaderLength : channelOpenHeaderLength+labelLength]
 	c.Protocol = raw[channelOpenHeaderLength+labelLength : channelOpenHeaderLength+labelLength+protocolLength]
 	return nil
+}
+
+func (c channelOpen) String() string {
+	return fmt.Sprintf("Open ChannelType(%s) Priority(%v) ReliabilityParameter(%d) Label(%s) Protocol(%s)", c.ChannelType, c.Priority, c.ReliabilityParameter, string(c.Label), string(c.Protocol))
 }

--- a/message_test.go
+++ b/message_test.go
@@ -95,3 +95,17 @@ func TestChannelAckUnmarshal(t *testing.T) {
 	_, ok := msgUncast.(*channelAck)
 	assert.True(t, ok, "Failed to cast to ChannelAck")
 }
+
+func TestChannelString(t *testing.T) {
+	channelString := channelOpen{
+		ChannelType:          ChannelTypeReliable,
+		Priority:             0,
+		ReliabilityParameter: 0,
+
+		Label:    []byte("foo"),
+		Protocol: []byte("bar"),
+	}.String()
+
+	assert.Equal(t, channelString, "Open ChannelType(Unknown) Priority(0) ReliabilityParameter(0) Label(foo) Protocol(bar)")
+	assert.Equal(t, channelAck{}.String(), "ACK")
+}


### PR DESCRIPTION
Before (Wrapped for linter)
```
invalid Message Type &{%!s(datachannel.ChannelType=0)
%!s(uint16=256) %!s(uint32=0) initial_data_channel }
```

Now (Wrapped for linter)
```
expected and actual message type does not match, wanted ACK
got Open ChannelType(PartialReliableRexmitUnordered) Priority(500)
ReliabilityParameter(750) Label(Sean) Protocol(Test)
```

Resolves #125
Resolves pion/webrtc#2258
