### PR TITLE
Commit reliability on client after receiving ACK

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -118,12 +118,7 @@ func Client(stream *sctp.Stream, config *Config) (*DataChannel, error) {
 			return nil, fmt.Errorf("failed to send ChannelOpen %w", err)
 		}
 	}
-	dc := newDataChannel(stream, config)
-
-	if err := dc.commitReliabilityParams(); err != nil {
-		return nil, err
-	}
-	return dc, nil
+	return newDataChannel(stream, config), nil
 }
 
 // Accept is used to accept incoming data channels over SCTP
@@ -285,6 +280,9 @@ func (c *DataChannel) handleDCEP(data []byte) error {
 
 	switch msg := msg.(type) {
 	case *channelAck:
+		if err := c.commitReliabilityParams(); err != nil {
+			return err
+		}
 		c.onOpenComplete()
 	default:
 		return fmt.Errorf("%w, wanted ACK got %v", ErrUnexpectedDataChannelType, msg)


### PR DESCRIPTION
From RFC 8832
https://www.rfc-editor.org/rfc/rfc8832.html#name-procedures, messages should be ordered till dialing/opening side receives ACK.

```
After the DATA_CHANNEL_OPEN message has been sent,
the sender of that message MAY start sending messages
containing user data without waiting for the reception
of the corresponding DATA_CHANNEL_ACK message. However,
before the DATA_CHANNEL_ACK message or any other message
has been received on a data channel, all other messages
containing user data and belonging to this data channel
MUST be sent ordered, no matter whether the data channel
is ordered or not. After the DATA_CHANNEL_ACK or any
other message has been received on the data channel,
messages containing user data MUST be sent ordered on
ordered data channels and MUST be sent unordered on
unordered data channels. Therefore, receiving a message
containing user data on an unused stream indicates an error.
In that case, the corresponding data channel MUST be closed,
as described in [RFC8831].
```

Without waiting, the data channel open failed on Accept side as the first message did not have PPI of DCEP. It got a user message and that caused the Accept to fail.

#### Description

#### Reference issue
Fixes #...
