### PR TITLE
Move R/W deadline into ReadWriteCloser

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -41,19 +41,13 @@ type WriteDeadliner interface {
 }
 
 // ReadWriteCloser is an extended io.ReadWriteCloser
-// that also implements our Reader and Writer.
+// that also implements our Reader, Writer and Deadliner.
 type ReadWriteCloser interface {
 	io.Reader
 	io.Writer
 	Reader
 	Writer
 	io.Closer
-}
-
-// ReadWriteCloserDeadliner is an extended ReadWriteCloser
-// that also implements r/w deadline.
-type ReadWriteCloserDeadliner interface {
-	ReadWriteCloser
 	ReadDeadliner
 	WriteDeadliner
 }


### PR DESCRIPTION
New interface can't pass pion/webrtc's
API check, add r/w deadline to the ReadWriteCloser
should work for existed codes.

#### Description

#### Reference issue
Fixes #...
