### PR TITLE
Check max label and protocol length

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,4 +26,10 @@ var (
 
 	// ErrUnexpectedDataChannelType is when a message type does not match the expected type.
 	ErrUnexpectedDataChannelType = errors.New("expected and actual message type does not match")
+
+	// ErrTooLongLabel is when the label is too long to fit in the 2 bytes allocated for its length.
+	ErrTooLongLabel = errors.New("label is too long, must be less than 65536 characters")
+
+	// ErrTooLongProtocol is when the protocol is too long to fit in the 2 bytes allocated for its length.
+	ErrTooLongProtocol = errors.New("protocol is too long, must be less than 65536 characters")
 )

--- a/message_channel_open.go
+++ b/message_channel_open.go
@@ -76,6 +76,11 @@ const (
 	ChannelTypePartialReliableTimedUnordered ChannelType = 0x82
 )
 
+const (
+	maxLabelLength    = 65535
+	maxProtocolLength = 65535
+)
+
 func (c ChannelType) String() string {
 	switch c {
 	case ChannelTypeReliable:
@@ -107,6 +112,13 @@ const (
 func (c *channelOpen) Marshal() ([]byte, error) {
 	labelLength := len(c.Label)
 	protocolLength := len(c.Protocol)
+
+	if labelLength > maxLabelLength {
+		return nil, ErrTooLongLabel
+	}
+	if protocolLength > maxProtocolLength {
+		return nil, ErrTooLongProtocol
+	}
 
 	totalLen := channelOpenHeaderLength + labelLength + protocolLength
 	raw := make([]byte, totalLen)

--- a/message_test.go
+++ b/message_test.go
@@ -95,8 +95,8 @@ func TestChannelString(t *testing.T) {
 }
 
 func TestChannelOpenUnmarshalVeryLongMessage(t *testing.T) {
-	label := strings.Repeat("a", 0xffff)
-	protocol := strings.Repeat("b", 0xffff)
+	label := strings.Repeat("a", maxLabelLength)
+	protocol := strings.Repeat("b", maxProtocolLength)
 
 	rawMsg := []byte{
 		0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -116,4 +116,30 @@ func TestChannelOpenUnmarshalVeryLongMessage(t *testing.T) {
 	assert.Equal(t, msg.ReliabilityParameter, uint32(0), "ReliabilityParameter should be 0")
 	assert.Equal(t, msg.Label, []uint8(label), "msg Label should be 'aaa...aaa'")
 	assert.Equal(t, msg.Protocol, []uint8(protocol), "msg protocol should be 'bbb...bbb'")
+}
+
+func TestChannelOpenMarshalTooLongLabel(t *testing.T) {
+	msg := channelOpen{
+		ChannelType:          ChannelTypeReliable,
+		Priority:             0,
+		ReliabilityParameter: 0,
+		Label:                []byte(strings.Repeat("a", maxLabelLength+1)),
+		Protocol:             []byte("bar"),
+	}
+
+	_, err := msg.Marshal()
+	assert.ErrorIs(t, err, ErrTooLongLabel)
+}
+
+func TestChannelOpenMarshalTooLongProtocol(t *testing.T) {
+	msg := channelOpen{
+		ChannelType:          ChannelTypeReliable,
+		Priority:             0,
+		ReliabilityParameter: 0,
+		Label:                []byte("foo"),
+		Protocol:             []byte(strings.Repeat("b", maxProtocolLength+1)),
+	}
+
+	_, err := msg.Marshal()
+	assert.ErrorIs(t, err, ErrTooLongProtocol)
 }


### PR DESCRIPTION
When they are too long, channelOpen.Marshal creates invalid packet.
